### PR TITLE
Backport stdint.h inclusion from libressl-portable repo

### DIFF
--- a/dev-libs/libressl/files/libressl-2.1.2-backport-stdint.patch
+++ b/dev-libs/libressl/files/libressl-2.1.2-backport-stdint.patch
@@ -1,0 +1,11 @@
+--- libressl-2.1.2/include/openssl/ssl.h.orig	2014-12-24 21:25:26.000000000 -0200
++++ libressl-2.1.2/include/openssl/ssl.h	2014-12-24 21:25:35.000000000 -0200
+@@ -143,6 +143,8 @@
+ #ifndef HEADER_SSL_H 
+ #define HEADER_SSL_H 
+ 
++#include <stdint.h>
++
+ #include <openssl/opensslconf.h>
+ #include <openssl/hmac.h>
+ #include <openssl/pem.h>

--- a/dev-libs/libressl/libressl-2.1.2-r2.ebuild
+++ b/dev-libs/libressl/libressl-2.1.2-r2.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+
+inherit eutils multilib-minimal
+
+DESCRIPTION="Free version of the SSL/TLS protocol forked from OpenSSL"
+HOMEPAGE="http://www.libressl.org/"
+SRC_URI="http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${P}.tar.gz"
+
+LICENSE="ISC openssl"
+SLOT="0"
+KEYWORDS="~amd64 ~mips ~ppc ~ppc64 ~x86"
+IUSE="+asm libtls static-libs"
+
+DEPEND="
+	abi_x86_32? (
+		!<=app-emulation/emul-linux-x86-baselibs-20140508
+		!app-emulation/emul-linux-x86-baselibs[-abi_x86_32(-)]
+	)"
+RDEPEND="${DEPEND}"
+PDEPEND="app-misc/ca-certificates"
+
+src_prepare() {
+	# Fix WX GNU-stack introduced by asm.  Also touch
+	# Makefile.in to prevent automake for rerunning.
+	epatch "${FILESDIR}"/${P}-fix-exe-gnu-stack.patch
+	# Include stdint.h in ssl.h
+	# See: http://permalink.gmane.org/gmane.os.openbsd.tech/39855
+	epatch "${FILESDIR}"/${P}-backport-stdint.patch
+	# Fix building with MUSL Libc
+	# Thanks, Voidlinux
+	epatch "${FILESDIR}"/${PN}-glibc.patch
+	touch crypto/Makefile.in
+
+	sed -i \
+		-e '/^CFLAGS=/s#-g##' \
+		-e '/^USER_CFLAGS=/s#-O2##' \
+		configure || die "fixing CFLAGS failed"
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf \
+		$(use_enable asm) \
+		$(use_enable libtls) \
+		$(use_enable static-libs static)
+}
+
+multilib_src_test() {
+	emake check
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	prune_libtool_files
+
+	# Include default config for openssl from openssl 1.0.1j
+	insinto /etc/ssl
+	newins "${S}/apps/openssl.cnf" openssl.cnf
+}


### PR DESCRIPTION
Should fix #28 #29 #30 #31
