### PR TITLE
Update Portage tarball for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,17 @@ before_script:
     - mkdir travis-overlay
     - mv !(travis-overlay) travis-overlay/
     - mv .git travis-overlay/
-    - wget "http://distfiles.gentoo.org/distfiles/portage-2.2.12.tar.bz2"
+    - wget "http://distfiles.gentoo.org/distfiles/portage-2.2.14.tar.bz2"
     - wget "http://distfiles.gentoo.org/snapshots/portage-latest.tar.xz"
     - sudo chmod 777 /etc/passwd /etc/group /etc /usr
     - echo "portage:x:250:250:portage:/var/tmp/portage:/bin/false" >> /etc/passwd
     - echo "portage::250:portage,travis" >> /etc/group
     - mkdir -p /etc/portage/ /usr/portage/distfiles
-    - tar xjf portage-2.2.12.tar.bz2
+    - tar xjf portage-2.2.14.tar.bz2
     - tar xJf portage-latest.tar.xz -C /usr/
-    - cp portage-2.2.12/cnf/repos.conf /etc/portage/
+    - cp portage-2.2.14/cnf/repos.conf /etc/portage/
     - rsync --recursive --links --safe-links --perms --times --omit-dir-times --compress --force --whole-file --delete --stats --human-readable --timeout=180 --exclude=/distfiles --checksum --quiet rsync://rsync.gentoo.org/gentoo-portage /usr/portage
     - ln -s /usr/portage/profiles/base/ /etc/portage/make.profile
     - cd travis-overlay
 script:
-    - "./../portage-2.2.12/bin/repoman full -i -d"
+    - "./../portage-2.2.14/bin/repoman full -i -d"


### PR DESCRIPTION
Update the Portage tarball as Travis CI builds [are currently failing](https://travis-ci.org/gentoo/libressl/builds/45101154#L92)
