### PR TITLE
Cleaned up OpenSSL Dummies, and Updated to 1.0.1L

### DIFF
--- a/dev-libs/openssl/metadata.xml
+++ b/dev-libs/openssl/metadata.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer>
-		<email>maintainer-wanted@gentoo.org</email>
-	</maintainer>
+<herd>base-system</herd>
+<use>
+ <flag name='bindist'>Disable EC/RC5 algorithms (as they seem to be patented) -- note: changes the ABI</flag>
+ <flag name='rfc3779'>Enable support for RFC 3779 (X.509 Extensions for IP Addresses and AS Identifiers)</flag>
+ <flag name='tls-heartbeat'>Enable the Heartbeat Extension in TLS and DTLS</flag>
+</use>
+<upstream>
+ <remote-id type="cpe">cpe:/a:openssl:openssl</remote-id>
+</upstream>
 </pkgmetadata>

--- a/dev-libs/openssl/openssl-1.0.0q.ebuild
+++ b/dev-libs/openssl/openssl-1.0.0q.ebuild
@@ -12,7 +12,7 @@ SRC_URI=""
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~sparc-fbsd ~x86-fbsd"
 IUSE="kerberos static-libs bindist"
 
 DEPEND=">=dev-libs/libressl-2.0.0[static-libs?,${MULTILIB_USEDEP}]"

--- a/dev-libs/openssl/openssl-1.0.1j.ebuild
+++ b/dev-libs/openssl/openssl-1.0.1j.ebuild
@@ -12,7 +12,7 @@ SRC_URI=""
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~arm-linux ~x86-linux"
 IUSE="kerberos static-libs bindist"
 
 DEPEND=">=dev-libs/libressl-2.0.0[static-libs?,${MULTILIB_USEDEP}]"

--- a/dev-libs/openssl/openssl-1.0.1k.ebuild
+++ b/dev-libs/openssl/openssl-1.0.1k.ebuild
@@ -12,7 +12,7 @@ SRC_URI=""
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~arm-linux ~x86-linux"
 IUSE="kerberos static-libs bindist"
 
 DEPEND=">=dev-libs/libressl-2.0.0[static-libs?,${MULTILIB_USEDEP}]"

--- a/dev-libs/openssl/openssl-1.0.1l.ebuild
+++ b/dev-libs/openssl/openssl-1.0.1l.ebuild
@@ -12,7 +12,7 @@ SRC_URI=""
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~arm-linux ~x86-linux"
 IUSE="kerberos static-libs bindist"
 
 DEPEND=">=dev-libs/libressl-2.0.0[static-libs?,${MULTILIB_USEDEP}]"


### PR DESCRIPTION
Updated Metadata, dummy ebuild.
Removed versions not in gentoo tree.
Sync'd Keywords.