### PR TITLE
Fix for libressl-2.2.0 and MUSL

### DIFF
--- a/dev-libs/libressl/files/libressl-2.2.0-musl.patch
+++ b/dev-libs/libressl/files/libressl-2.2.0-musl.patch
@@ -1,0 +1,11 @@
+diff -Naur libressl-2.2.0.orig/crypto/compat/getentropy_linux.c libressl-2.2.0/crypto/compat/getentropy_linux.c
+--- libressl-2.2.0.orig/crypto/compat/getentropy_linux.c	2015-06-30 23:42:09.873389199 -0700
++++ libressl-2.2.0/crypto/compat/getentropy_linux.c	2015-06-30 23:43:20.530057972 -0700
+@@ -28,7 +28,6 @@
+ #include <sys/resource.h>
+ #include <sys/syscall.h>
+ #ifdef SYS__sysctl
+-#include <sys/sysctl.h>
+ #include <linux/sysctl.h>
+ #endif
+ #include <sys/statvfs.h>

--- a/dev-libs/libressl/libressl-2.2.0.ebuild
+++ b/dev-libs/libressl/libressl-2.2.0.ebuild
@@ -29,6 +29,8 @@ PDEPEND="app-misc/ca-certificates"
 src_prepare() {
 	touch crypto/Makefile.in
 
+	epatch "${FILESDIR}"/${P}-musl.patch
+
 	sed -i \
 		-e '/^[ \t]*CFLAGS=/s#-g ##' \
 		-e '/^[ \t]*CFLAGS=/s#-g"#"#' \


### PR DESCRIPTION
Stumbled upon this while trying to do a hardened musl install. Already fixed upstream.