### PR TITLE
travis.yml: bump portage to 2.3.38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,10 @@ notifications:
     on_start: false     # default: false
 env:
     global:
-        - PORTAGE_VER="2.3.16"
-        - REPOMAN_VER="2.3.6"
+        - PORTAGE_VER="2.3.38"
 before_install:
     - sudo apt-get -qq update
-    - pip install lxml
+    - pip install lxml pyyaml
 before_script:
     - sudo chmod a+rwX /etc/passwd /etc/group /etc /usr
     - mkdir -p travis-overlay /etc/portage/ /usr/portage/distfiles
@@ -22,7 +21,6 @@ before_script:
     - mv .git travis-overlay/
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/spinner.sh"
     - wget -qO - "https://github.com/gentoo/portage/archive/portage-${PORTAGE_VER}.tar.gz" | tar xz
-    - wget -qO - "https://github.com/gentoo/portage/archive/repoman-${REPOMAN_VER}.tar.gz" | tar xz
     - wget -qO - "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" | tar xz -C /usr/portage --strip-components=1
     - chmod a+rwx spinner.sh
     - echo "portage:x:250:250:portage:/var/tmp/portage:/bin/false" >> /etc/passwd
@@ -32,4 +30,4 @@ before_script:
     - ln -s /usr/portage/profiles/default/linux/amd64/13.0 /etc/portage/make.profile
     - cd travis-overlay
 script:
-    - ./../spinner.sh "python ../portage-repoman-${REPOMAN_VER}/repoman/bin/repoman full -i -d"
+    - ./../spinner.sh "python ../portage-portage-${PORTAGE_VER}/repoman/bin/repoman full -i -d"


### PR DESCRIPTION
Remove redundancy: for now repoman is still being shipped with portage