### PR TITLE
layout.conf: define sign-commits & sign-manifests

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -2,3 +2,5 @@ masters = gentoo
 thin-manifests = true
 manifest-hashes = BLAKE2B SHA512
 manifest-required-hashes = SHA512
+sign-commits = true
+sign-manifests = false


### PR DESCRIPTION
If the user has `sign` in FEATURES, and	there is no `sign-manifests`
defined in layout.conf, repoman will assume it to be true.