### PR TITLE
Fixes for Aria2

### DIFF
--- a/net-misc/aria2/aria2-1.33.1.ebuild
+++ b/net-misc/aria2/aria2-1.33.1.ebuild
@@ -65,6 +65,7 @@ pkg_setup() {
 }
 
 src_prepare() {
+	eapply "${FILESDIR}"/aria2-libressl.patch
 	default
 	sed -i -e "s|/tmp|${T}|" test/*.cc test/*.txt || die "sed failed"
 }

--- a/net-misc/aria2/aria2-1.34.0.ebuild
+++ b/net-misc/aria2/aria2-1.34.0.ebuild
@@ -65,6 +65,7 @@ pkg_setup() {
 }
 
 src_prepare() {
+	eapply "${FILESDIR}"/${P}-make_unique.patch
 	default
 	sed -i -e "s|/tmp|${T}|" test/*.cc test/*.txt || die "sed failed"
 }

--- a/net-misc/aria2/aria2-1.34.0.ebuild
+++ b/net-misc/aria2/aria2-1.34.0.ebuild
@@ -65,6 +65,7 @@ pkg_setup() {
 }
 
 src_prepare() {
+	eapply "${FILESDIR}"/aria2-libressl.patch
 	eapply "${FILESDIR}"/${P}-make_unique.patch
 	default
 	sed -i -e "s|/tmp|${T}|" test/*.cc test/*.txt || die "sed failed"

--- a/net-misc/aria2/files/aria2-1.34.0-make_unique.patch
+++ b/net-misc/aria2/files/aria2-1.34.0-make_unique.patch
@@ -1,0 +1,44 @@
+From e8e04d6f22a507e8374651d3d2343cd9fb986993 Mon Sep 17 00:00:00 2001
+From: Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com>
+Date: Thu, 17 May 2018 18:39:44 +0900
+Subject: [PATCH] Fix build failure when InternalDHKeyExchange is used
+
+---
+ src/bignum.h | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/bignum.h b/src/bignum.h
+index e59ab6bbf..5fb4402bc 100644
+--- a/src/bignum.h
++++ b/src/bignum.h
+@@ -19,6 +19,8 @@
+ #include <memory>
+ #include <stdint.h>
+ 
++#include "a2functional.h"
++
+ namespace bignum {
+ 
+ template <size_t dim> class ulong {
+@@ -31,17 +33,17 @@ template <size_t dim> class ulong {
+   std::unique_ptr<char_t[]> buf_;
+ 
+ public:
+-  inline ulong() : buf_(make_unique<char_t[]>(dim)) {}
+-  inline ulong(size_t t) : buf_(make_unique<char_t[]>(dim))
++  inline ulong() : buf_(aria2::make_unique<char_t[]>(dim)) {}
++  inline ulong(size_t t) : buf_(aria2::make_unique<char_t[]>(dim))
+   {
+     memcpy(buf_.get(), (char_t*)&t, sizeof(t));
+   }
+-  inline ulong(const ulong<dim>& rhs) : buf_(make_unique<char_t[]>(dim))
++  inline ulong(const ulong<dim>& rhs) : buf_(aria2::make_unique<char_t[]>(dim))
+   {
+     memcpy(buf_.get(), rhs.buf_.get(), dim);
+   }
+   explicit inline ulong(const char_t* data, size_t size)
+-      : buf_(make_unique<char_t[]>(dim))
++      : buf_(aria2::make_unique<char_t[]>(dim))
+   {
+     if (size > dim) {
+       throw std::bad_alloc();

--- a/net-misc/aria2/files/aria2-libressl.patch
+++ b/net-misc/aria2/files/aria2-libressl.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libssl_compat.h b/src/libssl_compat.h
+index 0e03bfd7..cb2e3d97 100644
+--- a/src/libssl_compat.h
++++ b/src/libssl_compat.h
+@@ -44,6 +44,7 @@
+ #endif // !defined(LIBRESSL_VERSION_NUMBER)
+ 
+ #define OPENSSL_101_API                                                        \
+-  (!LIBRESSL_IN_USE && OPENSSL_VERSION_NUMBER >= 0x1010000fL)
++  ((!LIBRESSL_IN_USE && OPENSSL_VERSION_NUMBER >= 0x1010000fL) || \
++  (LIBRESSL_IN_USE && LIBRESSL_VERSION_NUMBER >= 0x20700000L))
+ 
+ #endif // LIBSSL_COMPAT_H


### PR DESCRIPTION
Fix two issues with Aria2.

The first issue was a build error with aria2-1.34.0. To fix this issue we are adding the patch that has already been added to upstream's master branch and the main gentoo repositories ebuild for aria2-1.34.0

The second issue is that aria2 does not build against libressl 2.7. To fix this, we add a patch fixes the logic to detect when to use the new openssl api. This patch has been submitted to upstream (https://github.com/aria2/aria2/pull/1213) , but it does has not yet been accepted by them.