### PR TITLE
Patch/ebuild for qtnetwork-5.11.2 to work with libressl

### DIFF
--- a/dev-qt/qtnetwork/files/qtnetwork-5.11.2-libressl.patch
+++ b/dev-qt/qtnetwork/files/qtnetwork-5.11.2-libressl.patch
@@ -1,0 +1,48 @@
+diff -Naurp old_qt/config.tests/unix/openssl11/openssl.cpp new_qt/config.tests/unix/openssl11/openssl.cpp
+--- old_qt/config.tests/unix/openssl11/openssl.cpp	2018-09-13 13:25:10.000000000 +0900
++++ new_qt/config.tests/unix/openssl11/openssl.cpp	2018-10-20 08:31:20.497180387 +0900
+@@ -39,7 +39,7 @@
+ 
+ #include <openssl/opensslv.h>
+ 
+-#if !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER-0 < 0x10100000L
++#if !defined(OPENSSL_VERSION_NUMBER) || OPENSSL_VERSION_NUMBER-0 < 0x10100000L  || defined(LIBRESSL_VERSION_NUMBER)
+ #  error "OpenSSL >= 1.1 is required"
+ #endif
+ 
+diff -Naurp old_qt/src/network/ssl/qsslcontext_openssl.cpp new_qt/src/network/ssl/qsslcontext_openssl.cpp
+--- old_qt/src/network/ssl/qsslcontext_openssl.cpp	2018-09-13 13:25:10.000000000 +0900
++++ new_qt/src/network/ssl/qsslcontext_openssl.cpp	2018-10-20 08:34:24.613169930 +0900
+@@ -248,7 +248,7 @@ void QSslContext::applyBackendConfig(QSs
+     if (sslContext->sslConfiguration.backendConfiguration().isEmpty())
+         return;
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
+     if (QSslSocket::sslLibraryVersionNumber() >= 0x10002000L) {
+         QSharedPointer<SSL_CONF_CTX> cctx(q_SSL_CONF_CTX_new(), &q_SSL_CONF_CTX_free);
+         if (cctx) {
+diff -Naurp old_qt/src/network/ssl/qsslsocket_openssl_symbols.cpp new_qt/src/network/ssl/qsslsocket_openssl_symbols.cpp
+--- old_qt/src/network/ssl/qsslsocket_openssl_symbols.cpp	2018-09-13 13:25:10.000000000 +0900
++++ new_qt/src/network/ssl/qsslsocket_openssl_symbols.cpp	2018-10-20 08:37:48.682266708 +0900
+@@ -406,7 +406,7 @@ DEFINEFUNC2(int, SSL_CTX_use_PrivateKey,
+ DEFINEFUNC2(int, SSL_CTX_use_RSAPrivateKey, SSL_CTX *a, a, RSA *b, b, return -1, return)
+ DEFINEFUNC3(int, SSL_CTX_use_PrivateKey_file, SSL_CTX *a, a, const char *b, b, int c, c, return -1, return)
+ DEFINEFUNC(X509_STORE *, SSL_CTX_get_cert_store, const SSL_CTX *a, a, return 0, return)
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
+ DEFINEFUNC(SSL_CONF_CTX *, SSL_CONF_CTX_new, DUMMYARG, DUMMYARG, return 0, return);
+ DEFINEFUNC(void, SSL_CONF_CTX_free, SSL_CONF_CTX *a, a, return ,return);
+ DEFINEFUNC2(void, SSL_CONF_CTX_set_ssl_ctx, SSL_CONF_CTX *a, a, SSL_CTX *b, b, return, return);
+diff -Naurp old_qt/src/network/ssl/qsslsocket_openssl_symbols_p.h new_qt/src/network/ssl/qsslsocket_openssl_symbols_p.h
+--- old_qt/src/network/ssl/qsslsocket_openssl_symbols_p.h	2018-09-13 13:25:10.000000000 +0900
++++ new_qt/src/network/ssl/qsslsocket_openssl_symbols_p.h	2018-10-20 08:39:53.219936039 +0900
+@@ -356,7 +356,7 @@ int q_SSL_CTX_use_PrivateKey(SSL_CTX *a,
+ int q_SSL_CTX_use_RSAPrivateKey(SSL_CTX *a, RSA *b);
+ int q_SSL_CTX_use_PrivateKey_file(SSL_CTX *a, const char *b, int c);
+ X509_STORE *q_SSL_CTX_get_cert_store(const SSL_CTX *a);
+-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
++#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
+ SSL_CONF_CTX *q_SSL_CONF_CTX_new();
+ void q_SSL_CONF_CTX_free(SSL_CONF_CTX *a);
+ void q_SSL_CONF_CTX_set_ssl_ctx(SSL_CONF_CTX *a, SSL_CTX *b);

--- a/dev-qt/qtnetwork/qtnetwork-5.11.2.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.11.2.ebuild
@@ -1,0 +1,64 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="Network abstraction library for the Qt5 framework"
+
+if [[ ${QT5_BUILD_TYPE} == release ]]; then
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86 ~amd64-fbsd"
+fi
+
+IUSE="bindist connman libproxy libressl networkmanager +ssl"
+
+DEPEND="
+	~dev-qt/qtcore-${PV}
+	>=sys-libs/zlib-1.2.5
+	connman? ( ~dev-qt/qtdbus-${PV} )
+	libproxy? ( net-libs/libproxy )
+	networkmanager? ( ~dev-qt/qtdbus-${PV} )
+	ssl? (
+		!libressl? ( dev-libs/openssl:0=[bindist=] )
+		libressl? ( dev-libs/libressl:0= )
+	)
+"
+RDEPEND="${DEPEND}
+	connman? ( net-misc/connman )
+	networkmanager? ( net-misc/networkmanager )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-libressl.patch
+)
+
+QT5_TARGET_SUBDIRS=(
+	src/network
+	src/plugins/bearer/generic
+)
+
+QT5_GENTOO_CONFIG=(
+	libproxy
+	ssl::SSL
+	ssl::OPENSSL
+	ssl:openssl-linked:LINKED_OPENSSL
+)
+
+QT5_GENTOO_PRIVATE_CONFIG=(
+	:network
+)
+
+pkg_setup() {
+	use connman && QT5_TARGET_SUBDIRS+=(src/plugins/bearer/connman)
+	use networkmanager && QT5_TARGET_SUBDIRS+=(src/plugins/bearer/networkmanager)
+}
+
+src_configure() {
+	local myconf=(
+		$(use connman || use networkmanager && echo -dbus-linked)
+		$(qt_use libproxy)
+		$(usex ssl -openssl-linked '')
+	)
+	qt5-build_src_configure
+}


### PR DESCRIPTION
The patch is essentially identical to that for 5.11.1, aside from the changes being on different lines, since the files changed between versions slightly.