### PR TITLE
dev-qt/qtnetwork: improved patch for libressl 2.8.x compatibility

### DIFF
--- a/dev-qt/qtnetwork/files/qtnetwork-5.11.1-libressl.patch
+++ b/dev-qt/qtnetwork/files/qtnetwork-5.11.1-libressl.patch
@@ -1,5 +1,6 @@
---- a/config.tests/unix/openssl11/openssl.cpp	2017-11-05 16:07:40.963385070 -0500
-+++ b/config.tests/unix/openssl11/openssl.cpp	2017-11-05 16:07:51.755255545 -0500
+diff -ur a/config.tests/unix/openssl11/openssl.cpp b/config.tests/unix/openssl11/openssl.cpp
+--- a/config.tests/unix/openssl11/openssl.cpp	2018-06-15 09:29:31.000000000 +0200
++++ b/config.tests/unix/openssl11/openssl.cpp	2018-11-07 19:00:26.251211691 +0100
 @@ -39,7 +39,7 @@
  
  #include <openssl/opensslv.h>
@@ -9,12 +10,10 @@
  #  error "OpenSSL >= 1.1 is required"
  #endif
  
-
-diff --git a/src/network/ssl/qsslcontext_openssl.cpp b/src/network/ssl/qsslcontext_openssl.cpp
-index 41b759364b..17ce5b4b30 100644
---- a/src/network/ssl/qsslcontext_openssl.cpp
-+++ b/src/network/ssl/qsslcontext_openssl.cpp
-@@ -248,7 +248,7 @@ void QSslContext::applyBackendConfig(QSslContext *sslContext)
+diff -ur a/src/network/ssl/qsslcontext_openssl.cpp b/src/network/ssl/qsslcontext_openssl.cpp
+--- a/src/network/ssl/qsslcontext_openssl.cpp	2018-06-15 09:29:31.000000000 +0200
++++ b/src/network/ssl/qsslcontext_openssl.cpp	2018-11-07 19:00:26.251211691 +0100
+@@ -248,7 +248,7 @@
      if (sslContext->sslConfiguration.backendConfiguration().isEmpty())
          return;
  
@@ -23,12 +22,35 @@ index 41b759364b..17ce5b4b30 100644
      if (QSslSocket::sslLibraryVersionNumber() >= 0x10002000L) {
          QSharedPointer<SSL_CONF_CTX> cctx(q_SSL_CONF_CTX_new(), &q_SSL_CONF_CTX_free);
          if (cctx) {
-
-diff --git a/src/network/ssl/qsslsocket_openssl_symbols.cpp b/src/network/ssl/qsslsocket_openssl_symbols.cpp
-index 82ff5e9e3a..77e5d03b7d 100644
---- a/src/network/ssl/qsslsocket_openssl_symbols.cpp
-+++ b/src/network/ssl/qsslsocket_openssl_symbols.cpp
-@@ -402,7 +402,7 @@ DEFINEFUNC2(int, SSL_CTX_use_PrivateKey, SSL_CTX *a, a, EVP_PKEY *b, b, return -
+diff -ur a/src/network/ssl/qsslsocket_opensslpre11_symbols_p.h b/src/network/ssl/qsslsocket_opensslpre11_symbols_p.h
+--- a/src/network/ssl/qsslsocket_opensslpre11_symbols_p.h	2018-06-15 09:29:31.000000000 +0200
++++ b/src/network/ssl/qsslsocket_opensslpre11_symbols_p.h	2018-11-07 19:00:57.976885459 +0100
+@@ -78,8 +78,8 @@
+ unsigned char * q_ASN1_STRING_data(ASN1_STRING *a);
+ BIO *q_BIO_new_file(const char *filename, const char *mode);
+ void q_ERR_clear_error();
+-Q_AUTOTEST_EXPORT BIO *q_BIO_new(BIO_METHOD *a);
+-Q_AUTOTEST_EXPORT BIO_METHOD *q_BIO_s_mem();
++Q_AUTOTEST_EXPORT BIO *q_BIO_new(const BIO_METHOD *a);
++Q_AUTOTEST_EXPORT const BIO_METHOD *q_BIO_s_mem();
+ int q_CRYPTO_num_locks();
+ void q_CRYPTO_set_locking_callback(void (*a)(int, int, const char *, int));
+ void q_CRYPTO_set_id_callback(unsigned long (*a)());
+diff -ur a/src/network/ssl/qsslsocket_openssl_symbols.cpp b/src/network/ssl/qsslsocket_openssl_symbols.cpp
+--- a/src/network/ssl/qsslsocket_openssl_symbols.cpp	2018-06-15 09:29:31.000000000 +0200
++++ b/src/network/ssl/qsslsocket_openssl_symbols.cpp	2018-11-07 19:00:57.975885469 +0100
+@@ -190,8 +190,8 @@
+ #endif
+ DEFINEFUNC2(BIO *, BIO_new_file, const char *filename, filename, const char *mode, mode, return 0, return)
+ DEFINEFUNC(void, ERR_clear_error, DUMMYARG, DUMMYARG, return, DUMMYARG)
+-DEFINEFUNC(BIO *, BIO_new, BIO_METHOD *a, a, return 0, return)
+-DEFINEFUNC(BIO_METHOD *, BIO_s_mem, void, DUMMYARG, return 0, return)
++DEFINEFUNC(BIO *, BIO_new, const BIO_METHOD *a, a, return 0, return)
++DEFINEFUNC(const BIO_METHOD *, BIO_s_mem, void, DUMMYARG, return 0, return)
+ DEFINEFUNC(int, CRYPTO_num_locks, DUMMYARG, DUMMYARG, return 0, return)
+ DEFINEFUNC(void, CRYPTO_set_locking_callback, void (*a)(int, int, const char *, int), a, return, DUMMYARG)
+ DEFINEFUNC(void, CRYPTO_set_id_callback, unsigned long (*a)(), a, return, DUMMYARG)
+@@ -406,7 +406,7 @@
  DEFINEFUNC2(int, SSL_CTX_use_RSAPrivateKey, SSL_CTX *a, a, RSA *b, b, return -1, return)
  DEFINEFUNC3(int, SSL_CTX_use_PrivateKey_file, SSL_CTX *a, a, const char *b, b, int c, c, return -1, return)
  DEFINEFUNC(X509_STORE *, SSL_CTX_get_cert_store, const SSL_CTX *a, a, return 0, return)
@@ -37,11 +59,10 @@ index 82ff5e9e3a..77e5d03b7d 100644
  DEFINEFUNC(SSL_CONF_CTX *, SSL_CONF_CTX_new, DUMMYARG, DUMMYARG, return 0, return);
  DEFINEFUNC(void, SSL_CONF_CTX_free, SSL_CONF_CTX *a, a, return ,return);
  DEFINEFUNC2(void, SSL_CONF_CTX_set_ssl_ctx, SSL_CONF_CTX *a, a, SSL_CTX *b, b, return, return);
-diff --git a/src/network/ssl/qsslsocket_openssl_symbols_p.h b/src/network/ssl/qsslsocket_openssl_symbols_p.h
-index 4fb8f26cf6..3a7de93113 100644
---- a/src/network/ssl/qsslsocket_openssl_symbols_p.h
-+++ b/src/network/ssl/qsslsocket_openssl_symbols_p.h
-@@ -352,7 +352,7 @@ int q_SSL_CTX_use_PrivateKey(SSL_CTX *a, EVP_PKEY *b);
+diff -ur a/src/network/ssl/qsslsocket_openssl_symbols_p.h b/src/network/ssl/qsslsocket_openssl_symbols_p.h
+--- a/src/network/ssl/qsslsocket_openssl_symbols_p.h	2018-06-15 09:29:31.000000000 +0200
++++ b/src/network/ssl/qsslsocket_openssl_symbols_p.h	2018-11-07 19:00:26.252211681 +0100
+@@ -356,7 +356,7 @@
  int q_SSL_CTX_use_RSAPrivateKey(SSL_CTX *a, RSA *b);
  int q_SSL_CTX_use_PrivateKey_file(SSL_CTX *a, const char *b, int c);
  X509_STORE *q_SSL_CTX_get_cert_store(const SSL_CTX *a);


### PR DESCRIPTION
Actually, dev-qt/qtnetwork does not build with libressl 2.8 versions.
pagorman made a patch in https://bugs.gentoo.org/670170 to make a successful build.
Then I merged his patch with 5.11.1 patch here in that pull request.