### PR TITLE
dev-qt/qtnetwork: Fix src_prepare

### DIFF
--- a/dev-qt/qtnetwork/qtnetwork-5.11.2.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.11.2.ebuild
@@ -57,7 +57,7 @@ src_prepare() {
 	has_version '<dev-libs/libressl-2.8.0' && \
 		eapply "${FILESDIR}/${P}-libressl-2.6.patch"
 
-	default
+	qt5-build_src_prepare
 }
 
 src_configure() {

--- a/dev-qt/qtnetwork/qtnetwork-5.11.3.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.11.3.ebuild
@@ -11,7 +11,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd"
 fi
 
-IUSE="bindist connman libproxy networkmanager libressl +ssl"
+IUSE="bindist connman libproxy libressl networkmanager +ssl"
 
 DEPEND="
 	~dev-qt/qtcore-${PV}
@@ -57,7 +57,7 @@ src_prepare() {
 	has_version '<dev-libs/libressl-2.8.0' && \
 		eapply "${FILESDIR}/${P}-libressl-2.6.patch"
 
-	default
+	qt5-build_src_prepare
 }
 
 src_configure() {


### PR DESCRIPTION
qt5-build_src_prepare must be called, otherwise it skips many
fixes from qt5-build eclass.

Package-Manager: Portage-2.3.52, Repoman-2.3.12