### PR TITLE
dev-python/cryptography: new package

### DIFF
--- a/dev-python/cryptography/cryptography-3.4.7-r2.ebuild
+++ b/dev-python/cryptography/cryptography-3.4.7-r2.ebuild
@@ -1,0 +1,77 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{7..10} pypy3 )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1 multiprocessing
+
+VEC_P=cryptography_vectors-${PV}
+DESCRIPTION="Library providing cryptographic recipes and primitives"
+HOMEPAGE="https://github.com/pyca/cryptography/ https://pypi.org/project/cryptography/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
+	test? ( mirror://pypi/c/cryptography_vectors/${VEC_P}.tar.gz )"
+
+LICENSE="|| ( Apache-2.0 BSD )"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv sparc x86"
+
+RDEPEND="
+	$(python_gen_cond_dep '
+		>=dev-python/cffi-1.8:=[${PYTHON_USEDEP}]
+	' 'python*')
+	"
+BDEPEND="
+	test? (
+		>=dev-python/hypothesis-1.11.4[${PYTHON_USEDEP}]
+		dev-python/iso8601[${PYTHON_USEDEP}]
+		dev-python/pretend[${PYTHON_USEDEP}]
+		dev-python/pyasn1-modules[${PYTHON_USEDEP}]
+		dev-python/pytz[${PYTHON_USEDEP}]
+		dev-python/pytest-subtests[${PYTHON_USEDEP}]
+		dev-python/pytest-xdist[${PYTHON_USEDEP}]
+	)"
+
+distutils_enable_tests pytest
+
+DEPEND="
+	>=dev-libs/openssl-1.0.2o-r6:0=
+	"
+RDEPEND+=${DEPEND}
+
+PATCHES=(
+	"${FILESDIR}/${P}-py310.patch"
+	"${FILESDIR}/${P}-libressl.patch"
+)
+
+src_prepare() {
+	default
+
+	# avoid automagic dependency on dev-libs/openssl[sslv3]
+	# https://bugs.gentoo.org/789450
+	export CPPFLAGS="${CPPFLAGS} -DOPENSSL_NO_SSL3_METHOD=1"
+
+	# work around availability macros not supported in GCC (yet)
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		local darwinok=0
+		if [[ ${CHOST##*-darwin} -ge 16 ]] ; then
+			darwinok=1
+		fi
+		sed -i -e 's/__builtin_available(macOS 10\.12, \*)/'"${darwinok}"'/' \
+			src/_cffi_src/openssl/src/osrandom_engine.c || die
+	fi
+
+	# this version does not really use Rust, it just creates a dummy
+	# extension to break stuff
+	export CRYPTOGRAPHY_DONT_BUILD_RUST=1
+	sed -e 's:from setuptools_rust import RustExtension:pass:' \
+		-e '/setup_requires/d' \
+		-i setup.py || die
+}
+
+python_test() {
+	local -x PYTHONPATH=${PYTHONPATH}:${WORKDIR}/${VEC_P}
+	epytest -n "$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")"
+}

--- a/dev-python/cryptography/files/cryptography-3.4.7-libressl.patch
+++ b/dev-python/cryptography/files/cryptography-3.4.7-libressl.patch
@@ -1,0 +1,155 @@
+From e540d3285f92d1e8d7d6249b8a6e36948e619fe4 Mon Sep 17 00:00:00 2001
+From: Charlie Li <git@vishwin.info>
+Date: Mon, 19 Apr 2021 17:25:22 -0400
+Subject: [PATCH 1/4] LibreSSL 3.3.2 supports SSL_OP_NO_DTLS*
+
+While here, bump CI
+---
+ src/_cffi_src/openssl/cryptography.py | 9 +++++++++
+ src/_cffi_src/openssl/ssl.py          | 2 +-
+ 2 files changed, 10 insertions(+), 1 deletions(-)
+
+diff --git a/src/_cffi_src/openssl/cryptography.py b/src/_cffi_src/openssl/cryptography.py
+index e2b5a13235a..ab296343906 100644
+--- a/src/_cffi_src/openssl/cryptography.py
++++ b/src/_cffi_src/openssl/cryptography.py
+@@ -32,6 +32,13 @@
+ #include <Winsock2.h>
+ #endif
+ 
++#if CRYPTOGRAPHY_IS_LIBRESSL
++    #define CRYPTOGRAPHY_LIBRESSL_332_OR_GREATER \
++        (LIBRESSL_VERSION_NUMBER >= 0x3030200f)
++#else
++#define CRYPTOGRAPHY_LIBRESSL_332_OR_GREATER (0)
++#endif
++
+ #define CRYPTOGRAPHY_OPENSSL_110F_OR_GREATER \
+     (OPENSSL_VERSION_NUMBER >= 0x1010006f && !CRYPTOGRAPHY_IS_LIBRESSL)
+ 
+@@ -59,6 +66,8 @@
+ static const int CRYPTOGRAPHY_NEEDS_OSRANDOM_ENGINE;
+ 
+ static const int CRYPTOGRAPHY_IS_LIBRESSL;
++
++static const int CRYPTOGRAPHY_LIBRESSL_332_OR_GREATER;
+ """
+ 
+ FUNCTIONS = """
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index 11a7d63a961..23cbc5ff425 100644
+--- a/src/_cffi_src/openssl/ssl.py
++++ b/src/_cffi_src/openssl/ssl.py
+@@ -585,7 +585,7 @@
+ static const long TLS_ST_OK = 0;
+ #endif
+ 
+-#if CRYPTOGRAPHY_IS_LIBRESSL
++#if CRYPTOGRAPHY_IS_LIBRESSL && !CRYPTOGRAPHY_LIBRESSL_332_OR_GREATER
+ static const long SSL_OP_NO_DTLSv1 = 0;
+ static const long SSL_OP_NO_DTLSv1_2 = 0;
+ long (*DTLS_set_link_mtu)(SSL *, long) = NULL;
+
+From ec2a1701a34a28783e2353befb9c5c057f65d782 Mon Sep 17 00:00:00 2001
+From: Charlie Li <git@vishwin.info>
+Date: Mon, 19 Apr 2021 17:41:33 -0400
+Subject: [PATCH 2/4] Fix preprocessor guards for LibreSSL's SSL_OP_NO_DTLS*
+
+DTLS_set_link_mtu and DTLS_get_link_min_mtu are not part of 3.3.2
+---
+ src/_cffi_src/openssl/ssl.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index 23cbc5ff425..a0b1641454e 100644
+--- a/src/_cffi_src/openssl/ssl.py
++++ b/src/_cffi_src/openssl/ssl.py
+@@ -585,9 +585,11 @@
+ static const long TLS_ST_OK = 0;
+ #endif
+ 
+-#if CRYPTOGRAPHY_IS_LIBRESSL && !CRYPTOGRAPHY_LIBRESSL_332_OR_GREATER
++#if CRYPTOGRAPHY_IS_LIBRESSL
++#if !CRYPTOGRAPHY_LIBRESSL_332_OR_GREATER
+ static const long SSL_OP_NO_DTLSv1 = 0;
+ static const long SSL_OP_NO_DTLSv1_2 = 0;
++#endif
+ long (*DTLS_set_link_mtu)(SSL *, long) = NULL;
+ long (*DTLS_get_link_min_mtu)(SSL *) = NULL;
+ #endif
+
+From 7d03d4477b4f06a3e1ec412afa0f2e4edb4e3893 Mon Sep 17 00:00:00 2001
+From: Charlie Li <git@vishwin.info>
+Date: Mon, 19 Apr 2021 18:16:14 -0400
+Subject: [PATCH 3/4] Switch to LESS_THAN context for LibreSSL 3.3.2
+
+While here, fix indents
+---
+ src/_cffi_src/openssl/cryptography.py | 8 ++++----
+ src/_cffi_src/openssl/ssl.py          | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/_cffi_src/openssl/cryptography.py b/src/_cffi_src/openssl/cryptography.py
+index ab296343906..0b468c8d719 100644
+--- a/src/_cffi_src/openssl/cryptography.py
++++ b/src/_cffi_src/openssl/cryptography.py
+@@ -33,10 +33,10 @@
+ #endif
+ 
+ #if CRYPTOGRAPHY_IS_LIBRESSL
+-    #define CRYPTOGRAPHY_LIBRESSL_332_OR_GREATER \
+-        (LIBRESSL_VERSION_NUMBER >= 0x3030200f)
++#define CRYPTOGRAPHY_LIBRESSL_LESS_THAN_332 \
++    (LIBRESSL_VERSION_NUMBER < 0x3030200f)
+ #else
+-#define CRYPTOGRAPHY_LIBRESSL_332_OR_GREATER (0)
++#define CRYPTOGRAPHY_LIBRESSL_LESS_THAN_332 (0)
+ #endif
+ 
+ #define CRYPTOGRAPHY_OPENSSL_110F_OR_GREATER \
+@@ -67,7 +67,7 @@
+ 
+ static const int CRYPTOGRAPHY_IS_LIBRESSL;
+ 
+-static const int CRYPTOGRAPHY_LIBRESSL_332_OR_GREATER;
++static const int CRYPTOGRAPHY_LIBRESSL_LESS_THAN_332;
+ """
+ 
+ FUNCTIONS = """
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index a0b1641454e..081ef041fa3 100644
+--- a/src/_cffi_src/openssl/ssl.py
++++ b/src/_cffi_src/openssl/ssl.py
+@@ -586,7 +586,7 @@
+ #endif
+ 
+ #if CRYPTOGRAPHY_IS_LIBRESSL
+-#if !CRYPTOGRAPHY_LIBRESSL_332_OR_GREATER
++#if CRYPTOGRAPHY_LIBRESSL_LESS_THAN_332
+ static const long SSL_OP_NO_DTLSv1 = 0;
+ static const long SSL_OP_NO_DTLSv1_2 = 0;
+ #endif
+
+From 843ef2dbfff33ea3018b04d926ccd6d1b629ef87 Mon Sep 17 00:00:00 2001
+From: Charlie Li <git@vishwin.info>
+Date: Mon, 19 Apr 2021 18:22:20 -0400
+Subject: [PATCH 4/4] Remove extra C variable declaration
+
+The variable is not actually used from Python
+---
+ src/_cffi_src/openssl/cryptography.py | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/_cffi_src/openssl/cryptography.py b/src/_cffi_src/openssl/cryptography.py
+index 0b468c8d719..b9c7a793b3b 100644
+--- a/src/_cffi_src/openssl/cryptography.py
++++ b/src/_cffi_src/openssl/cryptography.py
+@@ -66,8 +66,6 @@
+ static const int CRYPTOGRAPHY_NEEDS_OSRANDOM_ENGINE;
+ 
+ static const int CRYPTOGRAPHY_IS_LIBRESSL;
+-
+-static const int CRYPTOGRAPHY_LIBRESSL_LESS_THAN_332;
+ """
+ 
+ FUNCTIONS = """

--- a/dev-python/cryptography/files/cryptography-3.4.7-py310.patch
+++ b/dev-python/cryptography/files/cryptography-3.4.7-py310.patch
@@ -1,0 +1,301 @@
+diff --git a/src/cryptography/exceptions.py b/src/cryptography/exceptions.py
+index f5860590..3bd98d82 100644
+--- a/src/cryptography/exceptions.py
++++ b/src/cryptography/exceptions.py
+@@ -3,10 +3,10 @@
+ # for complete details.
+ 
+ 
+-from enum import Enum
++from cryptography import utils
+ 
+ 
+-class _Reasons(Enum):
++class _Reasons(utils.Enum):
+     BACKEND_MISSING_INTERFACE = 0
+     UNSUPPORTED_HASH = 1
+     UNSUPPORTED_CIPHER = 2
+diff --git a/src/cryptography/hazmat/primitives/_serialization.py b/src/cryptography/hazmat/primitives/_serialization.py
+index 96a5ed9b..160a6b89 100644
+--- a/src/cryptography/hazmat/primitives/_serialization.py
++++ b/src/cryptography/hazmat/primitives/_serialization.py
+@@ -3,13 +3,14 @@
+ # for complete details.
+ 
+ import abc
+-from enum import Enum
++
++from cryptography import utils
+ 
+ # This exists to break an import cycle. These classes are normally accessible
+ # from the serialization module.
+ 
+ 
+-class Encoding(Enum):
++class Encoding(utils.Enum):
+     PEM = "PEM"
+     DER = "DER"
+     OpenSSH = "OpenSSH"
+@@ -18,14 +19,14 @@ class Encoding(Enum):
+     SMIME = "S/MIME"
+ 
+ 
+-class PrivateFormat(Enum):
++class PrivateFormat(utils.Enum):
+     PKCS8 = "PKCS8"
+     TraditionalOpenSSL = "TraditionalOpenSSL"
+     Raw = "Raw"
+     OpenSSH = "OpenSSH"
+ 
+ 
+-class PublicFormat(Enum):
++class PublicFormat(utils.Enum):
+     SubjectPublicKeyInfo = "X.509 subjectPublicKeyInfo with PKCS#1"
+     PKCS1 = "Raw PKCS#1"
+     OpenSSH = "OpenSSH"
+@@ -34,7 +35,7 @@ class PublicFormat(Enum):
+     UncompressedPoint = "X9.62 Uncompressed Point"
+ 
+ 
+-class ParameterFormat(Enum):
++class ParameterFormat(utils.Enum):
+     PKCS3 = "PKCS3"
+ 
+ 
+diff --git a/src/cryptography/hazmat/primitives/kdf/kbkdf.py b/src/cryptography/hazmat/primitives/kdf/kbkdf.py
+index ac36474f..75fe7d51 100644
+--- a/src/cryptography/hazmat/primitives/kdf/kbkdf.py
++++ b/src/cryptography/hazmat/primitives/kdf/kbkdf.py
+@@ -4,7 +4,6 @@
+ 
+ 
+ import typing
+-from enum import Enum
+ 
+ from cryptography import utils
+ from cryptography.exceptions import (
+@@ -19,11 +18,11 @@ from cryptography.hazmat.primitives import constant_time, hashes, hmac
+ from cryptography.hazmat.primitives.kdf import KeyDerivationFunction
+ 
+ 
+-class Mode(Enum):
++class Mode(utils.Enum):
+     CounterMode = "ctr"
+ 
+ 
+-class CounterLocation(Enum):
++class CounterLocation(utils.Enum):
+     BeforeFixed = "before_fixed"
+     AfterFixed = "after_fixed"
+ 
+diff --git a/src/cryptography/hazmat/primitives/serialization/pkcs7.py b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+index bcd9e330..57aac7e3 100644
+--- a/src/cryptography/hazmat/primitives/serialization/pkcs7.py
++++ b/src/cryptography/hazmat/primitives/serialization/pkcs7.py
+@@ -3,8 +3,8 @@
+ # for complete details.
+ 
+ import typing
+-from enum import Enum
+ 
++from cryptography import utils
+ from cryptography import x509
+ from cryptography.hazmat.backends import _get_backend
+ from cryptography.hazmat.primitives import hashes, serialization
+@@ -35,7 +35,7 @@ _ALLOWED_PRIVATE_KEY_TYPES = typing.Union[
+ ]
+ 
+ 
+-class PKCS7Options(Enum):
++class PKCS7Options(utils.Enum):
+     Text = "Add text/plain MIME type"
+     Binary = "Don't translate input data into canonical MIME format"
+     DetachedSignature = "Don't embed data in the PKCS7 structure"
+diff --git a/src/cryptography/utils.py b/src/cryptography/utils.py
+index ef0fc443..9e571cfd 100644
+--- a/src/cryptography/utils.py
++++ b/src/cryptography/utils.py
+@@ -4,6 +4,7 @@
+ 
+ 
+ import abc
++import enum
+ import inspect
+ import sys
+ import typing
+@@ -162,3 +163,13 @@ int_from_bytes = deprecated(
+     "int_from_bytes is deprecated, use int.from_bytes instead",
+     DeprecatedIn34,
+ )
++
++
++# Python 3.10 changed representation of enums. We use well-defined object
++# representation and string representation from Python 3.9.
++class Enum(enum.Enum):
++    def __repr__(self):
++        return f"<{self.__class__.__name__}.{self._name_}: {self._value_!r}>"
++
++    def __str__(self):
++        return f"{self.__class__.__name__}.{self._name_}"
+diff --git a/src/cryptography/x509/base.py b/src/cryptography/x509/base.py
+index 5505fa3b..e3846c33 100644
+--- a/src/cryptography/x509/base.py
++++ b/src/cryptography/x509/base.py
+@@ -7,9 +7,9 @@ import abc
+ import datetime
+ import os
+ import typing
+-from enum import Enum
+ 
+ from cryptography.hazmat._types import _PRIVATE_KEY_TYPES, _PUBLIC_KEY_TYPES
++from cryptography import utils
+ from cryptography.hazmat.backends import _get_backend
+ from cryptography.hazmat.primitives import hashes, serialization
+ from cryptography.hazmat.primitives.asymmetric import (
+@@ -66,7 +66,7 @@ def _convert_to_naive_utc_time(time: datetime.datetime) -> datetime.datetime:
+         return time
+ 
+ 
+-class Version(Enum):
++class Version(utils.Enum):
+     v1 = 0
+     v3 = 2
+ 
+diff --git a/src/cryptography/x509/certificate_transparency.py b/src/cryptography/x509/certificate_transparency.py
+index d51bee92..d80f051a 100644
+--- a/src/cryptography/x509/certificate_transparency.py
++++ b/src/cryptography/x509/certificate_transparency.py
+@@ -5,15 +5,16 @@
+ 
+ import abc
+ import datetime
+-from enum import Enum
+ 
++from cryptography import utils
+ 
+-class LogEntryType(Enum):
++
++class LogEntryType(utils.Enum):
+     X509_CERTIFICATE = 0
+     PRE_CERTIFICATE = 1
+ 
+ 
+-class Version(Enum):
++class Version(utils.Enum):
+     v1 = 0
+ 
+ 
+diff --git a/src/cryptography/x509/extensions.py b/src/cryptography/x509/extensions.py
+index 6cae016a..742f1fa2 100644
+--- a/src/cryptography/x509/extensions.py
++++ b/src/cryptography/x509/extensions.py
+@@ -8,7 +8,6 @@ import datetime
+ import hashlib
+ import ipaddress
+ import typing
+-from enum import Enum
+ 
+ from cryptography import utils
+ from cryptography.hazmat._der import (
+@@ -634,7 +633,7 @@ class DistributionPoint(object):
+     crl_issuer = utils.read_only_property("_crl_issuer")
+ 
+ 
+-class ReasonFlags(Enum):
++class ReasonFlags(utils.Enum):
+     unspecified = "unspecified"
+     key_compromise = "keyCompromise"
+     ca_compromise = "cACompromise"
+@@ -978,7 +977,7 @@ class TLSFeature(ExtensionType):
+         return hash(tuple(self._features))
+ 
+ 
+-class TLSFeatureType(Enum):
++class TLSFeatureType(utils.Enum):
+     # status_request is defined in RFC 6066 and is used for what is commonly
+     # called OCSP Must-Staple when present in the TLS Feature extension in an
+     # X.509 certificate.
+diff --git a/src/cryptography/x509/name.py b/src/cryptography/x509/name.py
+index a579aa21..9069a9f4 100644
+--- a/src/cryptography/x509/name.py
++++ b/src/cryptography/x509/name.py
+@@ -3,14 +3,13 @@
+ # for complete details.
+ 
+ import typing
+-from enum import Enum
+ 
+ from cryptography import utils
+ from cryptography.hazmat.backends import _get_backend
+ from cryptography.x509.oid import NameOID, ObjectIdentifier
+ 
+ 
+-class _ASN1Type(Enum):
++class _ASN1Type(utils.Enum):
+     UTF8String = 12
+     NumericString = 18
+     PrintableString = 19
+diff --git a/src/cryptography/x509/ocsp.py b/src/cryptography/x509/ocsp.py
+index 1c5de73e..bcf210c1 100644
+--- a/src/cryptography/x509/ocsp.py
++++ b/src/cryptography/x509/ocsp.py
+@@ -6,8 +6,8 @@
+ import abc
+ import datetime
+ import typing
+-from enum import Enum
+ 
++from cryptography import utils
+ from cryptography import x509
+ from cryptography.hazmat.primitives import hashes, serialization
+ from cryptography.x509.base import (
+@@ -27,12 +27,12 @@ _OIDS_TO_HASH = {
+ }
+ 
+ 
+-class OCSPResponderEncoding(Enum):
++class OCSPResponderEncoding(utils.Enum):
+     HASH = "By Hash"
+     NAME = "By Name"
+ 
+ 
+-class OCSPResponseStatus(Enum):
++class OCSPResponseStatus(utils.Enum):
+     SUCCESSFUL = 0
+     MALFORMED_REQUEST = 1
+     INTERNAL_ERROR = 2
+@@ -58,7 +58,7 @@ def _verify_algorithm(algorithm):
+         )
+ 
+ 
+-class OCSPCertStatus(Enum):
++class OCSPCertStatus(utils.Enum):
+     GOOD = 0
+     REVOKED = 1
+     UNKNOWN = 2
+diff --git a/tests/test_cryptography_utils.py b/tests/test_cryptography_utils.py
+index 6b795e0c..803997ac 100644
+--- a/tests/test_cryptography_utils.py
++++ b/tests/test_cryptography_utils.py
+@@ -2,6 +2,7 @@
+ # 2.0, and the BSD License. See the LICENSE file in the root of this repository
+ # for complete details.
+ 
++import enum
+ import typing
+ 
+ import pytest
+@@ -51,3 +52,13 @@ class TestCachedProperty(object):
+         assert len(accesses) == 1
+         assert t.t == 14
+         assert len(accesses) == 1
++
++
++def test_enum():
++    class TestEnum(utils.Enum):
++        value = "something"
++
++    assert issubclass(TestEnum, enum.Enum)
++    assert isinstance(TestEnum.value, enum.Enum)
++    assert repr(TestEnum.value) == "<TestEnum.value: 'something'>"
++    assert str(TestEnum.value) == "TestEnum.value"


### PR DESCRIPTION
This is the gentoo ebuild + a backported commit from upstream, this can presumably be removed when cryptography makes a new release and gentoo updates to it.

I also removed the changes to `.github/workflows/ci.yml` from the patch file to allow it to apply cleanly.

See: https://github.com/pyca/cryptography/pull/5988