### PR TITLE
Bump LibreSSL 3.4.0-r1 patch to fix CVE-2021-41581

### DIFF
--- a/dev-libs/libressl/files/libressl-3.4.0-x509.patch
+++ b/dev-libs/libressl/files/libressl-3.4.0-x509.patch
@@ -1,0 +1,51 @@
+diff --git a/crypto/x509/x509_constraints.c b/crypto/x509/x509_constraints.c
+index fade58c..9ad5d4b 100644
+--- a/crypto/x509/x509_constraints.c
++++ b/crypto/x509/x509_constraints.c
+@@ -339,16 +339,16 @@ x509_constraints_parse_mailbox(uint8_t *candidate, size_t len,
+ 			if (c == '.')
+ 				goto bad;
+ 		}
+-		if (wi > DOMAIN_PART_MAX_LEN)
+-			goto bad;
+ 		if (accept) {
++		        if (wi > DOMAIN_PART_MAX_LEN)
++			        goto bad;
+ 			working[wi++] = c;
+ 			accept = 0;
+ 			continue;
+ 		}
+ 		if (candidate_local != NULL) {
+ 			/* We are looking for the domain part */
+-			if (wi > DOMAIN_PART_MAX_LEN)
++			if (wi >= DOMAIN_PART_MAX_LEN)
+ 				goto bad;
+ 			working[wi++] = c;
+ 			if (i == len - 1) {
+@@ -363,7 +363,7 @@ x509_constraints_parse_mailbox(uint8_t *candidate, size_t len,
+ 			continue;
+ 		}
+ 		/* We are looking for the local part */
+-		if (wi > LOCAL_PART_MAX_LEN)
++		if (wi >= LOCAL_PART_MAX_LEN)
+ 			break;
+ 
+ 		if (quoted) {
+@@ -383,6 +383,8 @@ x509_constraints_parse_mailbox(uint8_t *candidate, size_t len,
+ 			 */
+ 			if (c == 9)
+ 				goto bad;
++			if (wi >= LOCAL_PART_MAX_LEN)
++			        goto bad;
+ 			working[wi++] = c;
+ 			continue; /* all's good inside our quoted string */
+ 		}
+@@ -412,6 +414,8 @@ x509_constraints_parse_mailbox(uint8_t *candidate, size_t len,
+ 		}
+ 		if (!local_part_ok(c))
+ 			goto bad;
++		if (wi >= LOCAL_PART_MAX_LEN)
++		        goto bad;
+ 		working[wi++] = c;
+ 	}
+ 	if (candidate_local == NULL || candidate_domain == NULL)

--- a/dev-libs/libressl/libressl-3.4.0-r1.ebuild
+++ b/dev-libs/libressl/libressl-3.4.0-r1.ebuild
@@ -40,6 +40,7 @@ src_prepare() {
 		Makefile.in || die "Removing tests failed"
 	fi
 
+	eapply "${FILESDIR}"/${PN}-3.4.0-x509.patch
 	eapply "${FILESDIR}"/${PN}-2.8.3-solaris10.patch
 	#eapply "${FILESDIR}"/${PN}-3.2.2-build.patch
 	eapply_user


### PR DESCRIPTION
This includes the patch from OpenBSD's errata page (https://ftp.openbsd.org/pub/OpenBSD/patches/6.9/common/017_x509.patch.sig) that fixes CVE-2021-41581 for LibreSSL 3.4.0.