### PR TITLE
dev-lang/python: pull in OpenBSD patches to fix build

### DIFF
--- a/dev-lang/python/files/python-3.9.9-r1-libressl.patch
+++ b/dev-lang/python/files/python-3.9.9-r1-libressl.patch
@@ -1,0 +1,34 @@
+$OpenBSD: patch-Modules__hashopenssl_c,v 1.3 2022/01/21 04:25:12 kmos Exp $
+
+Index: Modules/_hashopenssl.c
+--- a/Modules/_hashopenssl.c
++++ b/Modules/_hashopenssl.c
+@@ -43,7 +43,8 @@
+ #  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"
+ #endif
+
+-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+ /* OpenSSL < 1.1.0 */
+ #define EVP_MD_CTX_new EVP_MD_CTX_create
+ #define EVP_MD_CTX_free EVP_MD_CTX_destroy
+
+$OpenBSD: patch-Modules__ssl_c,v 1.3 2021/11/18 15:45:28 tb Exp $
+
+XXX maybe this can go away now we have auto-init, I'm not sure exactly
+what python's lock protects
+
+Index: Modules/_ssl.c
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -213,6 +213,9 @@ extern const SSL_METHOD *TLSv1_2_method(void);
+ #if defined(OPENSSL_VERSION_1_1) && !defined(OPENSSL_NO_SSL2)
+ #define OPENSSL_NO_SSL2
+ #endif
++#if defined(LIBRESSL_VERSION_NUMBER) && defined(WITH_THREAD)
++#define HAVE_OPENSSL_CRYPTO_LOCK
++#endif
+
+ #ifndef PY_OPENSSL_1_1_API
+ /* OpenSSL 1.1 API shims for OpenSSL < 1.1.0 and LibreSSL < 2.7.0 */

--- a/dev-lang/python/python-3.9.9-r1.ebuild
+++ b/dev-lang/python/python-3.9.9-r1.ebuild
@@ -94,6 +94,7 @@ src_prepare() {
 
 	local PATCHES=(
 		"${WORKDIR}/${PATCHSET}"
+		"${FILESDIR}"/${PN}-3.9.9-r1-libressl.patch
 	)
 
 	default


### PR DESCRIPTION
Python 3.9.9-r1 build was failing with LibreSSL 3.5+.  These patches from OpenBSD seem to fix it quite well