### PR TITLE
dev-libs/libressl: Stabilize amd64 and arm64

### DIFF
--- a/dev-libs/libressl/libressl-3.5.2.ebuild
+++ b/dev-libs/libressl/libressl-3.5.2.ebuild
@@ -17,7 +17,7 @@ LICENSE="ISC openssl"
 # we'll try to use the max of either. However, if either change between
 # versions, we have to change the subslot to trigger rebuild of consumers.
 SLOT="0/48"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="+asm static-libs test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="test? ( static-libs )"

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -1,8 +1,0 @@
-# 2021-10-02
-# LibreSSL 3.4.0 is causing build issues on many packages.
-# Masked until build issues are solved.
-=dev-libs/libressl-3.4.0-r1
-
-# 2021-10-02
-# This version is affected by a vulnerability: CVE-2021-41581
-=dev-libs/libressl-3.4.0


### PR DESCRIPTION
Given the limited amount of possible testing and lack of known problems I think we should stabilize `3.5.2` for the keywords we know are being used.

Also added a commit to remove outdated package masks for libressl versions we do not include anymore.