### PR TITLE
dev-libs/libressl: Stabilize amd64 and arm64

### DIFF
--- a/dev-libs/libressl/libressl-3.5.3.ebuild
+++ b/dev-libs/libressl/libressl-3.5.3.ebuild
@@ -17,7 +17,7 @@ LICENSE="ISC openssl"
 # we'll try to use the max of either. However, if either change between
 # versions, we have to change the subslot to trigger rebuild of consumers.
 SLOT="0/52"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="+asm static-libs test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="test? ( static-libs )"


### PR DESCRIPTION
There should be no reason to not stabilize `3.5.3` since its nearly the same as `3.5.2`, but the slot was fixed for this version so expect rebuilds.