### PR TITLE
dev-libs/libevent: add 2.1.12-r1 + remove 2.1.12

### DIFF
--- a/dev-libs/libevent/libevent-2.1.12-r1.ebuild
+++ b/dev-libs/libevent/libevent-2.1.12-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,10 +16,10 @@ SRC_URI="
 LICENSE="BSD"
 
 SLOT="0/2.1-7"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="
 	+clock-gettime debug malloc-replacement +ssl static-libs test
-	+threads verbose-debug
+	verbose-debug
 "
 RESTRICT="!test? ( test )"
 
@@ -60,7 +60,6 @@ multilib_src_configure() {
 		$(use_enable ssl openssl) \
 		$(use_enable static-libs static) \
 		$(use_enable test libevent-regress) \
-		$(use_enable threads thread-support) \
 		$(use_enable verbose-debug) \
 		--disable-samples
 }


### PR DESCRIPTION
Applies upstream [gentoo/gentoo#b885790](https://github.com/gentoo/gentoo/commit/b885790c3a76f426aed746cbbf1fd433d9d43451)