### PR TITLE
dev-libs/libressl: Fix multilib header

### DIFF
--- a/dev-libs/libressl/libressl-3.7.1.ebuild
+++ b/dev-libs/libressl/libressl-3.7.1.ebuild
@@ -26,6 +26,8 @@ BDEPEND="verify-sig? ( sec-keys/openpgp-keys-libressl )"
 
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/libressl.asc
 
+MULTILIB_WRAPPED_HEADERS=( /usr/include/openssl/opensslconf.h )
+
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.8.3-solaris10.patch
 )


### PR DESCRIPTION
 Fixes: https://github.com/gentoo/libressl/issues/506