### PR TITLE
app-crypt/qc: sync ::gentoo

### DIFF
--- a/app-crypt/qca/qca-2.3.6-r1.ebuild
+++ b/app-crypt/qca/qca-2.3.6-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://kde/stable/${PN}/${PV}/${P}.tar.xz"
 
 LICENSE="LGPL-2.1"
 SLOT="2"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
+KEYWORDS="amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="botan debug doc examples gcrypt gpg logger nss pkcs11 sasl softstore +ssl test"
 
 RESTRICT="!test? ( test )"


### PR DESCRIPTION
keywords sync, preventing ::gentoo to be installed as ::gentoo is now stable.