### PR TITLE
Slightly Change README.md to adress RDEPEND issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Use [`eselect-repository`](https://wiki.gentoo.org/wiki/Eselect/Repository):
 Now you can use `emerge --sync` or `emaint sync -r libressl` to sync this
 repository.
 
+```
+To prevent a dependency loop:
+Since dev-libs/libressl causes file collisions with dev-libs/openssl::gentoo,
+until the openssl::libressl fake package is installed.
+Fetch Libressl Packages First, and remove openssl after, using following commands.
+# emerge -f libressl
+# emerge -C openssl 
+# emerge -1q libressl
+# emerge @preserved-rebuild
+
+```
+
 ## links
 
 [Gentoo bug report](https://bugs.gentoo.org/show_bug.cgi?id=508750)


### PR DESCRIPTION
Are we allowed to change this readme.md?
Following these steps i added will make it really easy to just, swap over.
We all know its not the best solution but gentoo dependency tracking can be terrible, and the use flag was slightly better.
But alas this is gone and we are now hacking it via fake packages. 