### PR TITLE
dev-libs/openssl: sync USE/KEYWORDS

### DIFF
--- a/dev-libs/openssl/openssl-3.8.1.ebuild
+++ b/dev-libs/openssl/openssl-3.8.1.ebuild
@@ -10,9 +10,9 @@ HOMEPAGE="https://wiki.gentoo.org/wiki/Project:LibreSSL"
 LICENSE="metapackage"
 
 SLOT="0/55" # .so version of libssl/libcrypto
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~s390 ~sparc x86 ~amd64-linux ~ppc-macos ~x64-macos ~x64-solaris"
-IUSE="+asm sslv3 static-libs test"
-REQUIRED_USE="!sslv3"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="+asm quic sctp static-libs test sslv3"
+REQUIRED_USE="!quic !sslv3"
 RESTRICT="!test? ( test )"
 
 DEPEND="dev-libs/libressl:${SLOT}[asm=,static-libs=,test=,${MULTILIB_USEDEP}]"

--- a/dev-libs/openssl/openssl-3.9.0.ebuild
+++ b/dev-libs/openssl/openssl-3.9.0.ebuild
@@ -10,9 +10,9 @@ HOMEPAGE="https://wiki.gentoo.org/wiki/Project:LibreSSL"
 LICENSE="metapackage"
 
 SLOT="0/56" # .so version of libssl/libcrypto
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~s390 ~sparc x86 ~amd64-linux ~ppc-macos ~x64-macos ~x64-solaris"
-IUSE="+asm sslv3 static-libs test"
-REQUIRED_USE="!sslv3"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="+asm quic sctp static-libs test sslv3"
+REQUIRED_USE="!quic !sslv3"
 RESTRICT="!test? ( test )"
 
 DEPEND="dev-libs/libressl:${SLOT}[asm=,static-libs=,test=,${MULTILIB_USEDEP}]"


### PR DESCRIPTION
Update Keywords and IUSE to resolve dependency issues with unstable curl.
quic was added to curl, enabled default, block quic usage, curl ~arch now may require gnutls or no quic 