### PR TITLE
net-analyzer/openbsd-netcat: new package

### DIFF
--- a/net-analyzer/openbsd-netcat/metadata.xml
+++ b/net-analyzer/openbsd-netcat/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>libressl@gentoo.org</email>
+	</maintainer>
+</pkgmetadata>
+

--- a/net-analyzer/openbsd-netcat/openbsd-netcat-1.99999.ebuild
+++ b/net-analyzer/openbsd-netcat/openbsd-netcat-1.99999.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="dummy package for dev-libs/libressl[netcat]"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:LibreSSL"
+S="${WORKDIR}"
+
+LICENSE="metapackage"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~ppc-macos ~x64-macos ~x64-solaris"
+
+RDEPEND="dev-libs/libressl[netcat]"


### PR DESCRIPTION
This is a dummy package for 'dev-libs/libressl[netcat]'.

Some packages in ::gentoo (like 'app-emulation/libvirt') depend on 'net-analyzer/openbsd-netcat'.

'dev-libs/libressl[netcat]' is the same thing, just without Debian patches.

A revbump is needed to remove a blocker, or it can be delayed to the next version bump.