### PR TITLE
dev-libs/libressl: always use noexecstack

### DIFF
--- a/dev-libs/libressl/libressl-4.3.1.ebuild
+++ b/dev-libs/libressl/libressl-4.3.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/libressl.asc
-inherit autotools multilib-minimal verify-sig
+inherit autotools multilib-minimal verify-sig toolchain-funcs flag-o-matic
 
 DESCRIPTION="Free version of the SSL/TLS protocol forked from OpenSSL"
 HOMEPAGE="https://www.libressl.org/"
@@ -58,6 +58,8 @@ multilib_src_configure() {
 		$(use_enable netcat nc)
 		$(use_enable test tests)
 	)
+	append-cflags -Wa,--noexecstack
+	append-cxxflags -Wa,--noexecstack
 	econf "${args[@]}"
 }
 


### PR DESCRIPTION
add -Wa,--noexecstack to avoid executable stack

LibreSSL's assembly code can cause the linker to mark libcrypto.so.57 with an executable stack (GNU_STACK: RWX). 
This breaks Python’s  build because the dynamic linker refuses to load such a library:
[ERROR] _hashlib failed to import: libcrypto.so.57: cannot enable executable stack as shared object requires: Invalid argument
[ERROR] _ssl failed to import: libcrypto.so.57: cannot enable executable stack as shared object requires: Invalid argument

Tested on default/linux/amd64/23.0/no-multilib